### PR TITLE
Replace meta-linaro with meta-arm

### DIFF
--- a/machine/meta-xt-images-generic-armv8/conf/layer.conf
+++ b/machine/meta-xt-images-generic-armv8/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_COLLECTIONS += "generic-armv8"
 BBFILE_PATTERN_generic-armv8 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_generic-armv8 = "10"
 
-LAYERDEPENDS_generic-armv8 = "linaro-toolchain"
+LAYERDEPENDS_generic-armv8 = "meta-arm"
 
 # There are multiple providers available for iasl-native,
 # e.g. iasl-native, acpica-native. Select iasl explicitly.

--- a/machine/meta-xt-images-rcar-gen3/doc/bblayers.conf
+++ b/machine/meta-xt-images-rcar-gen3/doc/bblayers.conf
@@ -9,8 +9,8 @@ BBLAYERS ?= " \
   ${TOPDIR}/../poky/meta \
   ${TOPDIR}/../poky/meta-poky \
   ${TOPDIR}/../poky/meta-yocto-bsp \
+  ${TOPDIR}/../meta-arm/meta-arm-toolchain \
   ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
-  ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \

--- a/machine/meta-xt-images-rcar-gen3/doc/local-wayland.conf
+++ b/machine/meta-xt-images-rcar-gen3/doc/local-wayland.conf
@@ -243,14 +243,14 @@ CONF_VERSION = "1"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
-# Linaro GCC
-GCCVERSION = "linaro-5.2"
+# arm GCC
+GCCVERSION = "9.3.0"
 
 # add the static lib to SDK toolchain
 SDKIMAGE_FEATURES_append = " staticdev-pkgs"
 
 # Disable optee in meta-linaro layer
-BBMASK = "meta-linaro/meta-optee/recipes-security/optee"
+BBMASK = "meta-arm/meta-arm/recipes-security/optee"
 
 # Enable Gfx Pkgs
 MACHINE_FEATURES_append = " gsx"

--- a/recipes-domd/domd-image-minimal/domd-image-minimal.bb
+++ b/recipes-domd/domd-image-minimal/domd-image-minimal.bb
@@ -4,7 +4,7 @@ require inc/domx-image-weston.inc
 
 # these layers will be added to bblayers.conf on do_configure
 XT_QUIRK_BB_ADD_LAYER += " \
-    meta-linaro/meta-optee \
+    meta-arm/meta-arm/recipes-sequrity \
 "
 
 ################################################################################

--- a/recipes-domd/domd-image-weston/domd-image-weston.bb
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bb
@@ -9,7 +9,7 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 # these layers will be added to bblayers.conf on do_configure
 XT_QUIRK_BB_ADD_LAYER += " \
     meta-xt-images-vgpu \
-    meta-linaro/meta-optee \
+    meta-arm/meta-arm/recipes-security \
 "
 
 ################################################################################


### PR DESCRIPTION
meta-linaro meta layer was replaced with meta-arm because
recipes from meta-linaro-toolchain have been transitioned to
meta-arm-toolchain
https://git.linaro.org/openembedded/meta-linaro.git/commit/?h=dunfell&id=6198c7b7eb6ebf0ec5fc0f333d033aa107970b6a

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>