### PR TITLE
optee: Remove unused patch

### DIFF
--- a/recipes-domd/domd-image-minimal/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -2,6 +2,7 @@
 ALLOW_EMPTY_${PN} = "1"
 
 SRC_URI = " git://github.com/xen-troops/optee_os.git"
+SRC_URI_remove = "file://change-cryptodome-to-crypto-module.patch"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 

--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -2,6 +2,8 @@
 ALLOW_EMPTY_${PN} = "1"
 
 SRC_URI = " git://github.com/xen-troops/optee_os.git"
+SRC_URI_remove = "file://change-cryptodome-to-crypto-module.patch"
+
 PV = "git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"


### PR DESCRIPTION
Removed redundant patch
patchchange-cryptodome-to-crypto-module.patch
from installation sources.

It is used in meta-renesas to fix sign_encrypt.py file,
but since SRC_URI is overloaded with xen-troops souces,
it causes build failer.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>