### PR TITLE
domx:xen: Remove python dependency to fix xen build

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/doc/bblayers.conf
+++ b/machine/meta-xt-images-rcar-gen3/doc/bblayers.conf
@@ -14,6 +14,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-python2 \
   ${TOPDIR}/../meta-selinux \
   ${TOPDIR}/../meta-virtualization \
   "

--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -57,6 +57,7 @@ EXTRA_OEMAKE += "PVRSRV_VZ_NUM_OSID=${XT_PVR_NUM_OSID}"
 RDEPENDS_${PN} = " \
     kernel-module-gles \
     python \
+    python-clang \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'libgbm wayland-kms', '', d)} \
 "
 

--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module_1.11.bb
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module_1.11.bb
@@ -5,6 +5,8 @@ PREFERRED_VERSION_gles-module-egl-headers = "1.11"
 
 DEPENDS += " \
     clang-native \
+    python-native \
+    python-clang-native \
     wayland-protocols \
 "
 DEPENDS_remove = " \

--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
@@ -35,7 +35,7 @@ KERNEL_MODULE_PACKAGE_SUFFIX = ""
 KERNEL_MODULE_AUTOLOAD_append = " pvrsrvkm"
 
 KBUILD_DIR ?= "${S}/build/linux/${RCAR_TARGET}_linux"
-KBUILD_OUTDIR ?= "binary_${RCAR_TARGET}_linux_${BUILD}/target_aarch64/kbuild/"
+KBUILD_OUTDIR ?= "binary_${RCAR_TARGET}_linux_nullws_drm_${BUILD}/target_aarch64/kbuild/"
 
 EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_BUILDDIR}"
 EXTRA_OEMAKE += "CROSS_COMPILE=${CROSS_COMPILE}"


### PR DESCRIPTION
There is no python2 in dunfell. Remove python from runtime dependencies to enable xen build