### PR TITLE
domx:linux-generic-armv8: Update licence checksum

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-kernel/linux/linux-generic-armv8.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-kernel/linux/linux-generic-armv8.bb
@@ -17,7 +17,7 @@ KMETA = "kernel-meta"
 LINUX_KERNEL_TYPE = "tiny"
 LINUX_VERSION ?= "4.14.0"
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
Update licence checksum defined in poky to fix build issue.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>